### PR TITLE
Conjured Item Specs

### DIFF
--- a/gilded_rose_spec.rb
+++ b/gilded_rose_spec.rb
@@ -185,7 +185,7 @@ describe "#update_quality" do
 
       context "on sell date" do
         Given(:initial_sell_in) { 0 }
-        Then { item.quality.should == initial_quality-2 }
+        Then { item.quality.should == initial_quality-4 }
         Then { item.sell_in.should == initial_sell_in-1 }
 
         context "at zero quality" do
@@ -196,7 +196,7 @@ describe "#update_quality" do
 
       context "after sell date" do
         Given(:initial_sell_in) { -10 }
-        Then { item.quality.should == initial_quality-2 }
+        Then { item.quality.should == initial_quality-4 }
         Then { item.sell_in.should == initial_sell_in-1 }
 
         context "at zero quality" do


### PR DESCRIPTION
Hey Jim.

I worked your version of the Gilded Rose Kata today.  I'm going to use it as an exercise for the OK.rb group tonight.  Thanks for preparing this for us.

Anyway, I was butting horns with a couple of your specs and just thought I would mention that I'm not sure I agree with them.  Conjured items "degrade in Quality twice as fast as normal items."  To me, that means they are -2 before the sell date, but -4 afterward (twice as fast as the normal -2).

I went looking around to see if I could find an official answer to this question.  I didn't really.  However, at least one other person who has worked with your code [agrees with me](https://github.com/dpiddy/gilded_rose_kata/blob/dpiddy-solution-1/gilded_rose.rb#L100).

So, this changes the specs if you feel it's warranted.

Thanks again.
