### PR TITLE
Modified tests to remove RSpec warnings

### DIFF
--- a/gilded_rose_spec.rb
+++ b/gilded_rose_spec.rb
@@ -162,7 +162,7 @@ describe "#update_quality" do
     end
 
     context "conjured item" do
-      before { pending }
+      before { skip }
       Given(:name) { "Conjured Mana Cake" }
 
       Invariant { item.sell_in.should == initial_sell_in-1 }

--- a/gilded_rose_spec.rb
+++ b/gilded_rose_spec.rb
@@ -13,64 +13,64 @@ describe "#update_quality" do
     context "normal item" do
       Given(:name) { "NORMAL ITEM" }
 
-      Invariant { item.sell_in.should == initial_sell_in-1 }
+      Invariant { expect(item.sell_in).to eq(initial_sell_in-1) }
 
       context "before sell date" do
-        Then { item.quality.should == initial_quality-1 }
+        Then { expect(item.quality).to eq(initial_quality-1) }
       end
 
       context "on sell date" do
         Given(:initial_sell_in) { 0 }
-        Then { item.quality.should == initial_quality-2 }
+        Then { expect(item.quality).to eq(initial_quality-2) }
       end
 
       context "after sell date" do
         Given(:initial_sell_in) { -10 }
-        Then { item.quality.should == initial_quality-2 }
+        Then { expect(item.quality).to eq(initial_quality-2) }
       end
 
       context "of zero quality" do
         Given(:initial_quality) { 0 }
-        Then { item.quality.should == 0 }
+        Then { expect(item.quality).to eq(0) }
       end
     end
 
     context "Aged Brie" do
       Given(:name) { "Aged Brie" }
 
-      Invariant { item.sell_in.should == initial_sell_in-1 }
+      Invariant { expect(item.sell_in).to eq(initial_sell_in-1) }
 
       context "before sell date" do
-        Then { item.quality.should == initial_quality+1 }
+        Then { expect(item.quality).to eq(initial_quality+1) }
 
         context "with max quality" do
           Given(:initial_quality) { 50 }
-          Then { item.quality.should == initial_quality }
+          Then { expect(item.quality).to eq(initial_quality) }
         end
       end
 
       context "on sell date" do
         Given(:initial_sell_in) { 0 }
-        Then { item.quality.should == initial_quality+2 }
+        Then { expect(item.quality).to eq(initial_quality+2) }
 
         context "near max quality" do
           Given(:initial_quality) { 49 }
-          Then { item.quality.should == 50 }
+          Then { expect(item.quality).to eq(50) }
         end
 
         context "with max quality" do
           Given(:initial_quality) { 50 }
-          Then { item.quality.should == initial_quality }
+          Then { expect(item.quality).to eq(initial_quality) }
         end
       end
 
       context "after sell date" do
         Given(:initial_sell_in) { -10 }
-        Then { item.quality.should == initial_quality+2 }
+        Then { expect(item.quality).to eq(initial_quality+2) }
 
         context "with max quality" do
           Given(:initial_quality) { 50 }
-          Then { item.quality.should == initial_quality }
+          Then { expect(item.quality).to eq(initial_quality) }
         end
       end
     end
@@ -79,31 +79,31 @@ describe "#update_quality" do
       Given(:initial_quality) { 80 }
       Given(:name) { "Sulfuras, Hand of Ragnaros" }
 
-      Invariant { item.sell_in.should == initial_sell_in }
+      Invariant { expect(item.sell_in).to eq(initial_sell_in) }
 
       context "before sell date" do
-        Then { item.quality.should == initial_quality }
+        Then { expect(item.quality).to eq(initial_quality) }
       end
 
       context "on sell date" do
         Given(:initial_sell_in) { 0 }
-        Then { item.quality.should == initial_quality }
+        Then { expect(item.quality).to eq(initial_quality) }
       end
 
       context "after sell date" do
         Given(:initial_sell_in) { -10 }
-        Then { item.quality.should == initial_quality }
+        Then { expect(item.quality).to eq(initial_quality) }
       end
     end
 
     context "Backstage pass" do
       Given(:name) { "Backstage passes to a TAFKAL80ETC concert" }
 
-      Invariant { item.sell_in.should == initial_sell_in-1 }
+      Invariant { expect(item.sell_in).to eq(initial_sell_in-1) }
 
       context "long before sell date" do
         Given(:initial_sell_in) { 11 }
-        Then { item.quality.should == initial_quality+1 }
+        Then { expect(item.quality).to eq(initial_quality+1) }
 
         context "at max quality" do
           Given(:initial_quality) { 50 }
@@ -112,52 +112,52 @@ describe "#update_quality" do
 
       context "medium close to sell date (upper bound)" do
         Given(:initial_sell_in) { 10 }
-        Then { item.quality.should == initial_quality+2 }
+        Then { expect(item.quality).to eq(initial_quality+2) }
 
         context "at max quality" do
           Given(:initial_quality) { 50 }
-          Then { item.quality.should == initial_quality }
+          Then { expect(item.quality).to eq(initial_quality) }
         end
       end
 
       context "medium close to sell date (lower bound)" do
         Given(:initial_sell_in) { 6 }
-        Then { item.quality.should == initial_quality+2 }
+        Then { expect(item.quality).to eq(initial_quality+2) }
 
         context "at max quality" do
           Given(:initial_quality) { 50 }
-          Then { item.quality.should == initial_quality }
+          Then { expect(item.quality).to eq(initial_quality) }
         end
       end
 
       context "very close to sell date (upper bound)" do
         Given(:initial_sell_in) { 5 }
-        Then { item.quality.should == initial_quality+3 }
+        Then { expect(item.quality).to eq(initial_quality+3) }
 
         context "at max quality" do
           Given(:initial_quality) { 50 }
-          Then { item.quality.should == initial_quality }
+          Then { expect(item.quality).to eq(initial_quality) }
         end
       end
 
       context "very close to sell date (lower bound)" do
         Given(:initial_sell_in) { 1 }
-        Then { item.quality.should == initial_quality+3 }
+        Then { expect(item.quality).to eq(initial_quality+3) }
 
         context "at max quality" do
           Given(:initial_quality) { 50 }
-          Then { item.quality.should == initial_quality }
+          Then { expect(item.quality).to eq(initial_quality) }
         end
       end
 
       context "on sell date" do
         Given(:initial_sell_in) { 0 }
-        Then { item.quality.should == 0 }
+        Then { expect(item.quality).to eq(0) }
       end
 
       context "after sell date" do
         Given(:initial_sell_in) { -10 }
-        Then { item.quality.should == 0 }
+        Then { expect(item.quality).to eq(0) }
       end
     end
 
@@ -165,35 +165,35 @@ describe "#update_quality" do
       before { skip }
       Given(:name) { "Conjured Mana Cake" }
 
-      Invariant { item.sell_in.should == initial_sell_in-1 }
+      Invariant { expect(item.sell_in).to eq(initial_sell_in-1) }
 
       context "before the sell date" do
         Given(:initial_sell_in) { 5 }
-        Then { item.quality.should == initial_quality-2 }
+        Then { expect(item.quality).to eq(initial_quality-2) }
 
         context "at zero quality" do
           Given(:initial_quality) { 0 }
-          Then { item.quality.should == initial_quality }
+          Then { expect(item.quality).to eq(initial_quality) }
         end
       end
 
       context "on sell date" do
         Given(:initial_sell_in) { 0 }
-        Then { item.quality.should == initial_quality-4 }
+        Then { expect(item.quality).to eq(initial_quality-4) }
 
         context "at zero quality" do
           Given(:initial_quality) { 0 }
-          Then { item.quality.should == initial_quality }
+          Then { expect(item.quality).to eq(initial_quality) }
         end
       end
 
       context "after sell date" do
         Given(:initial_sell_in) { -10 }
-        Then { item.quality.should == initial_quality-4 }
+        Then { expect(item.quality).to eq(initial_quality-4) }
 
         context "at zero quality" do
           Given(:initial_quality) { 0 }
-          Then { item.quality.should == initial_quality }
+          Then { expect(item.quality).to eq(initial_quality) }
         end
       end
     end
@@ -209,10 +209,10 @@ describe "#update_quality" do
 
     When { update_quality(items) }
 
-    Then { items[0].quality.should == 9 }
-    Then { items[0].sell_in.should == 4 }
+    Then { expect(items[0].quality).to eq(9) }
+    Then { expect(items[0].sell_in).to eq(4) }
 
-    Then { items[1].quality.should == 11 }
-    Then { items[1].sell_in.should == 2 }
+    Then { expect(items[1].quality).to eq(11) }
+    Then { expect(items[1].sell_in).to eq(2) }
   end
 end


### PR DESCRIPTION
With RSpec 3.0, the :should syntax has been deprecated in favor of syntax using :expect. Running the tests was giving a warning about this deprecation.

Also, RSpec shows pending tests that pass as failed tests. This can be changed through config modifications, but I think it's easier of all tests pass from the beginning. Changed "pending" to "skip" in the initial 'conjured item' test set, so that they no longer fail because of this.
